### PR TITLE
Teach `pecs config set` to handle numeric values

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pecs",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pecs",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Flex your ECS muscles",
   "main": "lib/pecs.js",
   "scripts": {

--- a/src/pecs.js
+++ b/src/pecs.js
@@ -92,7 +92,8 @@ Yargs
       .command('set <key> <val>', 'Set environment variable for a service', (subyargs) => {
         subyargs
           .group(['cluster', 'services'], 'Common args:')
-          .example('$0 config set DEBUG true -c dev -s api', 'set dev api env var DEBUG to "true"');
+          .example('$0 config set DEBUG true -c dev -s api', 'set dev api env var DEBUG to "true"')
+          .coerce('val', val => `${val}`);
       }, wrap(configure))
       .command('unset <key>', 'Unset environment variable for a service', (subyargs) => {
         subyargs


### PR DESCRIPTION
yargs was being helpful and converting an argument like "50" into a
Number, but trying to use anything other than a string would throw an
error when we try to set it.

Now, we explicitly coerce the value to a string.