### PR TITLE
Remove maxResults from listServices

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -21,7 +21,7 @@ function extractNameFromARN(arn) {
 // Fetches list of all service names if none are provided
 async function getServices(ecs, cluster, services) {
   if (!services.length) {
-    const list = await ecs.listServices({ cluster, maxResults: 10 }).promise();
+    const list = await ecs.listServices({ cluster }).promise();
     const serviceNames = list.serviceArns.map(extractNameFromARN);
     services.push(...serviceNames);
   }


### PR DESCRIPTION
At the original dev time for this project fetching info for more than 10 services seemed excessive given we were doing cluster per service and the plan was to implement pagination if we decided to put them all in one cluster.

Last night this caused us to miss a service configuration being updated (because we were unable to see the config for ALL services (we now have 18) and verify the results of our change via pecs).

The default page size is `1000` according to [this](https://docs.aws.amazon.com/cli/latest/userguide/pagination.html) which should serve us well into the foreseeable future.