### PR TITLE
Preserve placement constraints when releasing

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -9,8 +9,9 @@ const PATH_SEP = '/';
 const MONITOR_UPDATE_TIME_MS = 3 * 1000; // 3 Seconds
 const WRITABLE_TASK_DEF_PARAMS = [
   'containerDefinitions',
-  'volumes',
   'family',
+  'placementConstraints',
+  'volumes',
 ];
 
 // ECS resource ARN format:


### PR DESCRIPTION
Placement constraints were accidentally being removed from the airflow task.
After this is merged we'll need to update / bump ci-base.